### PR TITLE
index.d.ts - Enable passing other <a> props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 
-interface GithubCornerProps {
+interface GithubCornerProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
     href?: string;
     size?: number | string;
     direction?: string;


### PR DESCRIPTION
As the code now, TypeScript won't allow passing other `<a>` props, like `target` to the `<GithubCorner>` component, as they are not part of `GithubCornerProps` - this extends `GithubCornerProps` to include all `<a>` props.