### PR TITLE
import AnchorHTMLAttributes in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSProperties } from 'react';
+import { CSSProperties, AnchorHTMLAttributes } from 'react';
 
 interface GithubCornerProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
     href?: string;


### PR DESCRIPTION
This is needed for https://github.com/skratchdot/react-github-corner/pull/49 to actually work...